### PR TITLE
bug fix: not surpport gulp.src(glob,{base:'***'})

### DIFF
--- a/lib/gulp-css-spritesmith.js
+++ b/lib/gulp-css-spritesmith.js
@@ -48,7 +48,8 @@ function gulpCssSprite(options) {
             var spriteData = data.spriteData;
             var spriteFile = new gutil.File({
                 contents: new Buffer(spriteData.image, 'binary'),
-                path: spriteData.imagePath
+                path: spriteData.imagePath,
+                base:file.base
             });
             self.push(spriteFile);
 


### PR DESCRIPTION
gulp.src(glob,{base:'***'})这种情况下，css输出目录不真确问题。不支持gulp.src中指定option.base参数